### PR TITLE
ユーザー詳細ページの実装

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,0 +1,4 @@
+class UsersController < ApplicationController
+  def show
+  end
+end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,4 +1,6 @@
 class UsersController < ApplicationController
   def show
+    @user = User.find(params[:id])
+    @prototypes = @user.prototypes.order("created_at DESC")
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,6 +1,6 @@
 class UsersController < ApplicationController
   def show
     @user = User.find(params[:id])
-    @prototypes = @user.prototypes.order("created_at DESC")
+    @prototypes = @user.prototypes.order('created_at DESC')
   end
 end

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -1,0 +1,2 @@
+module UsersHelper
+end

--- a/app/models/prototype.rb
+++ b/app/models/prototype.rb
@@ -1,6 +1,6 @@
 class Prototype < ApplicationRecord
   belongs_to :user
   has_one_attached :image
-  
+
   validates :title, :catch_copy, :concept, :image, presence: true
 end

--- a/app/views/prototypes/_prototype.html.erb
+++ b/app/views/prototypes/_prototype.html.erb
@@ -5,6 +5,6 @@
     <p class="card__summary">
       <%= prototype.catch_copy %>
     </p>
-    <%= link_to "by #{prototype.user.name}", root_path, class: :card__user %>
+    <%= link_to "by #{prototype.user.name}", user_path(prototype.user_id), class: :card__user %>
   </div>
 </div>

--- a/app/views/prototypes/index.html.erb
+++ b/app/views/prototypes/index.html.erb
@@ -3,7 +3,7 @@
     <% if user_signed_in? %>
       <div class="greeting">
         こんにちは、
-        <%= link_to "#{current_user.name}さん", root_path, class: :greeting__link %>
+        <%= link_to "#{current_user.name}さん", user_path(current_user.id), class: :greeting__link %>
       </div>
     <% end %>
     <div class="card__wrapper">

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,0 +1,35 @@
+<div class="main">
+  <div class="inner">
+    <div class="user__wrapper">
+      <h2 class="page-heading">
+        <%= "ユーザー名さんの情報"%>
+      </h2>
+      <table class="table">
+        <tbody>
+          <tr>
+            <th class="table__col1">名前</th>
+            <td class="table__col2"><%= "ユーザー名" %></td>
+          </tr>
+          <tr>
+            <th class="table__col1">プロフィール</th>
+            <td class="table__col2"><%= "ユーザーのプロフィール" %></td>
+          </tr>
+          <tr>
+            <th class="table__col1">所属</th>
+            <td class="table__col2"><%= "ユーザーの所属" %></td>
+          </tr>
+          <tr>
+            <th class="table__col1">役職</th>
+            <td class="table__col2"><%= "ユーザーの役職" %></td>
+          </tr>
+        </tbody>
+      </table>
+      <h2 class="page-heading">
+        <%= "ユーザー名さんのプロトタイプ"%>
+      </h2>
+      <div class="user__card">
+        <%# 部分テンプレートでそのユーザーが投稿したプロトタイプ投稿一覧を表示する %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -25,7 +25,7 @@
         </tbody>
       </table>
       <h2 class="page-heading">
-        <%= "#{@user_name}さんのプロトタイプ"%>
+        <%= "#{@user.name}さんのプロトタイプ"%>
       </h2>
       <div class="user__card">
         <%= render partial: 'prototypes/prototype', collection: @prototypes %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -2,33 +2,33 @@
   <div class="inner">
     <div class="user__wrapper">
       <h2 class="page-heading">
-        <%= "ユーザー名さんの情報"%>
+        <%= "#{@user.name}さんの情報"%>
       </h2>
       <table class="table">
         <tbody>
           <tr>
             <th class="table__col1">名前</th>
-            <td class="table__col2"><%= "ユーザー名" %></td>
+            <td class="table__col2"><%= @user.name %></td>
           </tr>
           <tr>
             <th class="table__col1">プロフィール</th>
-            <td class="table__col2"><%= "ユーザーのプロフィール" %></td>
+            <td class="table__col2"><%= @user.profile %></td>
           </tr>
           <tr>
             <th class="table__col1">所属</th>
-            <td class="table__col2"><%= "ユーザーの所属" %></td>
+            <td class="table__col2"><%= @user.occupation %></td>
           </tr>
           <tr>
             <th class="table__col1">役職</th>
-            <td class="table__col2"><%= "ユーザーの役職" %></td>
+            <td class="table__col2"><%= @user.position %></td>
           </tr>
         </tbody>
       </table>
       <h2 class="page-heading">
-        <%= "ユーザー名さんのプロトタイプ"%>
+        <%= "#{@user_name}さんのプロトタイプ"%>
       </h2>
       <div class="user__card">
-        <%# 部分テンプレートでそのユーザーが投稿したプロトタイプ投稿一覧を表示する %>
+        <%= render partial: 'prototypes/prototype', collection: @prototypes %>
       </div>
     </div>
   </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,4 +2,5 @@ Rails.application.routes.draw do
   devise_for :users
   root to: 'prototypes#index'
   resources :prototypes, only: [:index, :new, :create]
+  resources :users, only: :show
 end

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class UsersControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -1,4 +1,4 @@
-require "test_helper"
+require 'test_helper'
 
 class UsersControllerTest < ActionDispatch::IntegrationTest
   # test "the truth" do


### PR DESCRIPTION
# What
- ユーザー詳細表示ページは、ログイン状況に関係なく、誰でも見ることができる
- 各ページのユーザー名をクリックすると、該当ユーザーの詳細ページへ遷移する
- ユーザーの詳細ページには、そのユーザーの詳細情報（名前・プロフィール・所属・役職）を表示する
- ユーザーの詳細ページには、そのユーザーが投稿したプロトタイプの情報（プロトタイプ名・投稿者・画像・キャッチコピー）を表示する
- プロトタイプ情報の画像を表示する



# Why
### isuue #2 の実装のため

---
## 挙動イメージ
**ログイン状態で、ユーザー詳細表示ページへ遷移**
[![Image from Gyazo](https://i.gyazo.com/57f6dbe8543934ae74d7a2839f762fc1.gif)](https://gyazo.com/57f6dbe8543934ae74d7a2839f762fc1)


**ログアウト状態で、ユーザー詳細表示ページへ遷移**
[![Image from Gyazo](https://i.gyazo.com/353ca733158594f657f20e2b91efc831.gif)](https://gyazo.com/353ca733158594f657f20e2b91efc831)