### PR TITLE
コメント投稿機能の実装

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,0 +1,2 @@
+class CommentsController < ApplicationController
+end

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,2 +1,4 @@
 class CommentsController < ApplicationController
+  def create
+  end
 end

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,4 +1,17 @@
 class CommentsController < ApplicationController
   def create
+    @comment = Comment.new(comment_params)
+    if @comment.save
+      redirect_to prototype_path(params[:prototype_id])
+    else
+      @prototype = @comment.prototype
+      @comments = @prototype.comments
+      render 'prototypes/show', status: :unprocessable_entity
+    end
+  end
+
+  private
+  def comment_params
+    params.require(:comment).permit(:content).merge(user_id: current_user.id, prototype_id: params[:prototype_id])
   end
 end

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -11,6 +11,7 @@ class CommentsController < ApplicationController
   end
 
   private
+
   def comment_params
     params.require(:comment).permit(:content).merge(user_id: current_user.id, prototype_id: params[:prototype_id])
   end

--- a/app/controllers/prototypes_controller.rb
+++ b/app/controllers/prototypes_controller.rb
@@ -18,6 +18,8 @@ class PrototypesController < ApplicationController
 
   def show
     @prototype = Prototype.find(params[:id])
+    @comment = Comment.new
+    @comments = @prototype.comments.includes(:user)
   end
 
   private

--- a/app/helpers/comments_helper.rb
+++ b/app/helpers/comments_helper.rb
@@ -1,0 +1,2 @@
+module CommentsHelper
+end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,0 +1,3 @@
+class Comment < ApplicationRecord
+
+end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,3 +1,6 @@
 class Comment < ApplicationRecord
+  belongs_to :user
+  belongs_to :prototype
 
+  validates :content, presence: true
 end

--- a/app/models/prototype.rb
+++ b/app/models/prototype.rb
@@ -1,6 +1,7 @@
 class Prototype < ApplicationRecord
   belongs_to :user
   has_one_attached :image
+  has_many :commnets, dependent: :destroy
 
   validates :title, :catch_copy, :concept, :image, presence: true
 end

--- a/app/models/prototype.rb
+++ b/app/models/prototype.rb
@@ -1,7 +1,7 @@
 class Prototype < ApplicationRecord
   belongs_to :user
   has_one_attached :image
-  has_many :commnets, dependent: :destroy
+  has_many :comments, dependent: :destroy
 
   validates :title, :catch_copy, :concept, :image, presence: true
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,4 +6,5 @@ class User < ApplicationRecord
 
   validates :name, :profile, :occupation, :position, presence: true
   has_many :prototypes
+  has_many :comments, dependent: :destroy
 end

--- a/app/views/prototypes/show.html.erb
+++ b/app/views/prototypes/show.html.erb
@@ -4,10 +4,12 @@
       <p class="prototype__hedding">
         <%= @prototype.title %>
       </p>
-      <%= link_to "by #{ @prototype.user.name }", root_path, class: :prototype__user %>
+      <%= link_to "by #{ @prototype.user.name }", user_path(@prototype.user.id), class: :prototype__user %>
        <% if user_signed_in? && current_user.id == @prototype.user_id %>
           <div class="prototype__manage">
+            <%# 編集機能実装後にパスの変更要（変更後コメントを削除） %>
             <%= link_to "編集する", root_path, class: :prototype__btn %>
+            <%# 削除機能実装後にパスの変更要（変更後コメントを削除） %>
             <%= link_to "削除する", root_path, class: :prototype__btn %>
           </div>
         <% end %>
@@ -30,22 +32,26 @@
       </div>
       <div class="prototype__comments">
         <%# ログインしているユーザーには以下のコメント投稿フォームを表示する %>
-          <%# <%= form_with model: モデル名,local: true do |f|%>
+        <% if user_signed_in? %>
+          <%= form_with model: [@prototype, @comment],local: true do |f| %>
             <div class="field">
-              <%# <%= f.label :hoge, "コメント" %><br />
-              <%# <%= f.text_field :hoge, id:"comment_content" %>
+              <%= f.label :content, "コメント" %><br />
+              <%= f.text_field :content, id:"comment_content" %>
             </div>
             <div class="actions">
-              <%# <%= f.submit "送信する", class: :form__btn  %>
+              <%= f.submit "送信する", class: :form__btn %>
             </div>
-          <%# <% end %>
+          <% end %>
         <%# // ログインしているユーザーには上記を表示する %>
+        <% end %>
         <ul class="comments_lists">
           <%# 投稿に紐づくコメントを一覧する処理を記述する %>
-            <li class="comments_list">
-              <%# <%= " コメントのテキスト "%>
-              <%# <%= link_to "（ ユーザー名 ）", root_path, class: :comment_user %>
-            </li>
+            <% @comments.each do |comment| %>
+              <li class="comments_list">
+                <%= comment.content %>
+                <%= link_to "（ #{comment.user.name} ）", user_path(comment.user.id), class: :comment_user %>
+              </li>
+            <% end %>
           <%# // 投稿に紐づくコメントを一覧する処理を記述する %>
         </ul>
       </div>

--- a/app/views/prototypes/show.html.erb
+++ b/app/views/prototypes/show.html.erb
@@ -31,7 +31,6 @@
         </div>
       </div>
       <div class="prototype__comments">
-        <%# ログインしているユーザーには以下のコメント投稿フォームを表示する %>
         <% if user_signed_in? %>
           <%= form_with model: [@prototype, @comment],local: true do |f| %>
             <div class="field">
@@ -42,17 +41,14 @@
               <%= f.submit "送信する", class: :form__btn %>
             </div>
           <% end %>
-        <%# // ログインしているユーザーには上記を表示する %>
         <% end %>
         <ul class="comments_lists">
-          <%# 投稿に紐づくコメントを一覧する処理を記述する %>
             <% @comments.each do |comment| %>
               <li class="comments_list">
                 <%= comment.content %>
                 <%= link_to "（ #{comment.user.name} ）", user_path(comment.user.id), class: :comment_user %>
               </li>
             <% end %>
-          <%# // 投稿に紐づくコメントを一覧する処理を記述する %>
         </ul>
       </div>
     </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,8 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: 'prototypes#index'
-  resources :prototypes, only: [:index, :new, :create, :show]
+  resources :prototypes, only: [:index, :new, :create, :show] do
+    resources :comments, only: :create
+  end
   resources :users, only: :show
 end

--- a/db/migrate/20240128055757_create_comments.rb
+++ b/db/migrate/20240128055757_create_comments.rb
@@ -1,0 +1,10 @@
+class CreateComments < ActiveRecord::Migration[7.0]
+  def change
+    create_table :comments do |t|
+      t.text :content, null: false
+      t.references :user, null: false, foreign_key: true
+      t.references :prototype, null: false, foreing_key: true
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_01_24_011419) do
+ActiveRecord::Schema[7.0].define(version: 2024_01_28_055757) do
   create_table "active_storage_attachments", charset: "utf8", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -37,6 +37,16 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_24_011419) do
     t.bigint "blob_id", null: false
     t.string "variation_digest", null: false
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
+
+  create_table "comments", charset: "utf8", force: :cascade do |t|
+    t.text "content", null: false
+    t.bigint "user_id", null: false
+    t.bigint "prototype_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["prototype_id"], name: "index_comments_on_prototype_id"
+    t.index ["user_id"], name: "index_comments_on_user_id"
   end
 
   create_table "prototypes", charset: "utf8", force: :cascade do |t|
@@ -67,5 +77,6 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_24_011419) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "comments", "users"
   add_foreign_key "prototypes", "users"
 end

--- a/test/controllers/comments_controller_test.rb
+++ b/test/controllers/comments_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class CommentsControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/controllers/comments_controller_test.rb
+++ b/test/controllers/comments_controller_test.rb
@@ -1,4 +1,4 @@
-require "test_helper"
+require 'test_helper'
 
 class CommentsControllerTest < ActionDispatch::IntegrationTest
   # test "the truth" do

--- a/test/fixtures/comments.yml
+++ b/test/fixtures/comments.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the "{}" from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/models/comment_test.rb
+++ b/test/models/comment_test.rb
@@ -1,4 +1,4 @@
-require "test_helper"
+require 'test_helper'
 
 class CommentTest < ActiveSupport::TestCase
   # test "the truth" do

--- a/test/models/comment_test.rb
+++ b/test/models/comment_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class CommentTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
# What
- 必要な情報を適切に入力して「送信する」ボタンを押すと、コメント情報がデータベースに保存される。
- 正しくコメントを投稿できた場合は、
  - 投稿した詳細ページに遷移する。
  - 投稿したコメントとその投稿者名が、対象プロトタイプの詳細ページにのみ表示される。
- コメント投稿フォームは、ログイン状態のユーザーへのみ、詳細ページに表示される。
- フォームを空のまま投稿しようとすると、投稿できずにそのページに留まる。



# Why
プロジェクトボード：issue #10 （コメント投稿機能）の実装のため


## 挙動未確認の機能
- プロトタイプ情報を削除すると、紐づいたコメントも削除される。
- 理由：削除機能実装完了待ちのため

## 挙動イメージ
- 必要な情報を適切に入力して「送信する」ボタンを押すと、投稿したコメントとその投稿者名が対象プロトタイプの詳細ページに表示される。
[![Image from Gyazo](https://i.gyazo.com/8550d0d25a30f8b1dc94fde2bddeb29f.gif)](https://gyazo.com/8550d0d25a30f8b1dc94fde2bddeb29f)


- ログアウト状態で、プロトタイプ詳細ページに遷移し、コメント投稿フォームが表示されない。
[![Image from Gyazo](https://i.gyazo.com/a3aa267ea6b7814f7bdc291287c87842.gif)](https://gyazo.com/a3aa267ea6b7814f7bdc291287c87842)


- フォームを空のまま投稿しようとすると、投稿できずにそのページに留まる。
[![Image from Gyazo](https://i.gyazo.com/fd18574c739e2aa5b5b3159148eb6839.gif)](https://gyazo.com/fd18574c739e2aa5b5b3159148eb6839)