### PR TITLE
プロトタイプ情報　削除機能

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -268,6 +268,7 @@ GEM
 
 PLATFORMS
   x86_64-darwin-21
+  x86_64-darwin-22
   x86_64-linux
 
 DEPENDENCIES

--- a/app/controllers/prototypes_controller.rb
+++ b/app/controllers/prototypes_controller.rb
@@ -27,7 +27,7 @@ class PrototypesController < ApplicationController
     prototype.destroy
     redirect_to root_path
   end
-  
+
   private
 
   def prototype_params

--- a/app/controllers/prototypes_controller.rb
+++ b/app/controllers/prototypes_controller.rb
@@ -23,7 +23,9 @@ class PrototypesController < ApplicationController
   end
 
   def destroy
-    
+    prototype = Prototype.find(params[:id])
+    prototype.destroy
+    redirect_to root_path
   end
   
   private

--- a/app/controllers/prototypes_controller.rb
+++ b/app/controllers/prototypes_controller.rb
@@ -16,6 +16,14 @@ class PrototypesController < ApplicationController
     end
   end
 
+  def show
+    @prototype = Prototype.find(params[:id])
+  end
+
+  def destroy
+    
+  end
+  
   private
 
   def prototype_params

--- a/app/views/prototypes/show.html.erb
+++ b/app/views/prototypes/show.html.erb
@@ -9,8 +9,7 @@
           <div class="prototype__manage">
             <%# 編集機能実装後にパスの変更要（変更後コメントを削除） %>
             <%= link_to "編集する", root_path, class: :prototype__btn %>
-            <%# 削除機能実装後にパスの変更要（変更後コメントを削除） %>
-            <%= link_to "削除する", root_path, class: :prototype__btn %>
+            <%= link_to "削除する", prototype_path(@prototype.id), data: { turbo_method: :delete }, class: :prototype__btn %>
           </div>
         <% end %>
       <div class="prototype__image">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,6 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: 'prototypes#index'
-  resources :prototypes, only: [:index, :new, :create]
+  resources :prototypes, only: [:index, :new, :create, :destroy]
   resources :users, only: :show
 end


### PR DESCRIPTION
# What
・ログイン状態の場合にのみ、詳細ページから「削除する」ボタンをクリックすると
　自身が投稿したプロトタイプ情報を削除できる
（「ログイン状態の場合にのみ、自身が投稿したプロトタイプ情報を削除できること」とは、詳細ページ
　における「削除」ボタンの表示・非表示に加え、コントローラー側でも条件を設けることを指す）

・削除が完了すると、トップページへ遷移する

・ログアウト状態で削除しようとした場合、ログインページにリダイレクトされる
（「ログアウト状態で削除しようとした場合、ログインページにリダイレクトされること」とはURLを直
　接入力して確認することはできないが、コントローラー側でも条件を設けることを指す）

# Why
削除機能( #9 )を実装するため

# 動作確認
https://i.gyazo.com/79bee1bb1e3ebc28b79e16c3705737d3.mp4