### PR TITLE
プロトタイプ 編集機能 #8

### DIFF
--- a/app/controllers/prototypes_controller.rb
+++ b/app/controllers/prototypes_controller.rb
@@ -11,9 +11,9 @@ class PrototypesController < ApplicationController
 
   def edit
     @prototype = Prototype.find(params[:id])
-    return unless current_user.id != @prototype.user_id
-
-    redirect_to root_path
+    unless current_user.id == @prototype.user_id
+      redirect_to root_path
+    end
   end
 
   def update
@@ -21,7 +21,7 @@ class PrototypesController < ApplicationController
     if @prototype.update(prototype_params)
       redirect_to prototype_path(@prototype)
     else
-      render :edit
+      render :edit, status: :unprocessable_entity
     end
   end
 

--- a/app/controllers/prototypes_controller.rb
+++ b/app/controllers/prototypes_controller.rb
@@ -1,10 +1,28 @@
 class PrototypesController < ApplicationController
+  before_action :authenticate_user!, only: [:edit, :update, :new, :destroy]
+
   def index
     @prototypes = Prototype.includes(:user)
   end
 
   def new
     @prototype = Prototype.new
+  end
+
+  def edit
+    @prototype = Prototype.find(params[:id])
+    return unless current_user.id != @prototype.user_id
+
+    redirect_to root_path
+  end
+
+  def update
+    @prototype = Prototype.find(params[:id])
+    if @prototype.update(prototype_params)
+      redirect_to prototype_path(@prototype)
+    else
+      render :edit
+    end
   end
 
   def create

--- a/app/views/prototypes/edit.html.erb
+++ b/app/views/prototypes/edit.html.erb
@@ -1,0 +1,8 @@
+<div class="main">
+  <div class="inner">
+    <div class="form__wrapper">
+      <h2 class="page-heading">プロトタイプ編集</h2>
+      <%= render 'form', prototype: @prototype %>
+    </div>
+  </div>
+</div>

--- a/app/views/prototypes/show.html.erb
+++ b/app/views/prototypes/show.html.erb
@@ -7,8 +7,7 @@
       <%= link_to "by #{ @prototype.user.name }", user_path(@prototype.user.id), class: :prototype__user %>
        <% if user_signed_in? && current_user.id == @prototype.user_id %>
           <div class="prototype__manage">
-            <%# 編集機能実装後にパスの変更要（変更後コメントを削除） %>
-            <%= link_to "編集する", root_path, class: :prototype__btn %>
+            <%= link_to "編集する", edit_prototype_path(@prototype), class: :prototype__btn %>
             <%= link_to "削除する", prototype_path(@prototype.id), data: { turbo_method: :delete }, class: :prototype__btn %>
           </div>
         <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: 'prototypes#index'
-  resources :prototypes, only: [:index, :new, :create, :show, :destroy] do
+  resources :prototypes do
     resources :comments, only: :create
   end
   resources :users, only: :show


### PR DESCRIPTION
# What
*  プロトタイプの編集機能を実装しました。
* ログインユーザーが自分の投稿したプロトタイプのみ編集できるようにしました。
* ユーザーが編集フォームに入力した内容をデータベース反映させる機能を追加しました。
* 編集に失敗した場合、ユーザーは編集ページに留まり、入力済データはほじされます。
* 編集成功後、ユーザーは該当プロトタイプの詳細ページにリダイレクトされます。

# Why
* #8 実装条件より
* ユーザーが自身のプロトタイプの修正更新をする
* 投稿者以外のプロトタイプの防止

# GYAZO
* ログイン状態の投稿者は、プロトタイプ情報編集ページに遷移できる動画
* 必要な情報を適切に入力して「保存する」ボタンを押すと、プロトタイプの情報を編集できる動画
[![Image from Gyazo](https://i.gyazo.com/02693abaf450e237405f4476d7803f23.gif)](https://gyazo.com/02693abaf450e237405f4476d7803f23)





## 入力に問題がある状態で「保存する」ボタンが押された場合、情報は保存されず、そのページに留まる動画
[![Image from Gyazo](https://i.gyazo.com/572f53f57f5ebabc431d75c5e27dd73e.gif)](https://gyazo.com/572f53f57f5ebabc431d75c5e27dd73e)





## 何も編集せずに「保存する」ボタンを押しても、画像無しのプロトタイプにならない動画
[![Image from Gyazo](https://i.gyazo.com/0a355846a86451e7c93c020c6772c274.gif)](https://gyazo.com/0a355846a86451e7c93c020c6772c274)





## ログイン状態の場合でも、URLを直接入力して自身が投稿していないプロトタイプのプロトタイプ情報編集ページへ遷移しようとすると、トップページに遷移する動画
[![Image from Gyazo](https://i.gyazo.com/36de7e66ff07a090ee76ae338121274e.gif)](https://gyazo.com/36de7e66ff07a090ee76ae338121274e)





## ログアウト状態の場合は、URLを直接入力してプロトタイプ情報編集ページへ遷移しようとすると、ログインページに遷移する動画
[![Image from Gyazo](https://i.gyazo.com/61566fdd475cd835575d2c620390d3b8.gif)](https://gyazo.com/61566fdd475cd835575d2c620390d3b8)





## プロトタイプ情報について、すでに登録されている情報は、編集画面を開いた時点で表示される動画
[![Image from Gyazo](https://i.gyazo.com/70072bfd1056def0ca7655388eeb3398.gif)](https://gyazo.com/70072bfd1056def0ca7655388eeb3398)
