### PR TITLE
Basic認証

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -11,7 +11,7 @@ class ApplicationController < ActionController::Base
 
   def basic_auth
     authenticate_or_request_with_http_basic do |username, password|
-      username == 'admin' && password == '2222'
+      username == ENV["BASIC_AUTH_USER"] && password == ENV["BASIC_AUTH_PASSWORD"]
     end
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,10 +1,17 @@
 class ApplicationController < ActionController::Base
   before_action :configure_permitted_parameters, if: :devise_controller?
+  before_action :basic_auth
 
   private
 
   def
       configure_permitted_parameters
     devise_parameter_sanitizer.permit(:sign_up, keys: [:name, :profile, :occupation, :position])
+  end
+
+  def basic_auth
+    authenticate_or_request_with_http_basic do |username, password|
+      username == 'admin' && password == '2222'
+    end
   end
 end

--- a/app/controllers/prototypes_controller.rb
+++ b/app/controllers/prototypes_controller.rb
@@ -11,9 +11,9 @@ class PrototypesController < ApplicationController
 
   def edit
     @prototype = Prototype.find(params[:id])
-    unless current_user.id == @prototype.user_id
-      redirect_to root_path
-    end
+    return if current_user.id == @prototype.user_id
+
+    redirect_to root_path
   end
 
   def update


### PR DESCRIPTION
# What
・Basic認証を導入
・環境変数を設定(開発環境)

# Why
ユーザーとパスワードを設定し、それに一致したユーザーのみが、Webアプリケーションを利用できるようにするため。

# 挙動確認
・どのページにアクセスしてもBasic認証が要求されること。
[![Image from Gyazo](https://i.gyazo.com/93ad2cf5dd7c4137a52af4e0816865c7.gif)](https://gyazo.com/93ad2cf5dd7c4137a52af4e0816865c7)

・間違ったユーザー名とパスワードではアクセスできないこと。
[![Image from Gyazo](https://i.gyazo.com/a52c40e0cf73d6a50c6916fd2e634a12.gif)](https://gyazo.com/a52c40e0cf73d6a50c6916fd2e634a12)

・正しい情報を入力してログインできること。
[![Image from Gyazo](https://i.gyazo.com/829b6ae5c28d8bf160a9c3a05a295650.gif)](https://gyazo.com/829b6ae5c28d8bf160a9c3a05a295650)
